### PR TITLE
Attachment bar background color modification

### DIFF
--- a/chrome/MonterailOverlay/css/messenger.css
+++ b/chrome/MonterailOverlay/css/messenger.css
@@ -50,7 +50,7 @@
 
 #attachmentView>#attachmentBar {
     color: var(--message-list-text-color);
-    background-color: #fcfcfc;
+    background-color: var(--background-color);
 }
 
 .tabmail-tab .tab-background-middle[selected=true] {


### PR DESCRIPTION
This pull request is to modify the background color of the attachment bar to match the theme's global background color.

Reference: [https://github.com/conema/monterail-fulldark/issues/14](https://github.com/conema/monterail-fulldark/issues/14)